### PR TITLE
Adding default sysGE for seq2ge()

### DIFF
--- a/matlab/ceq2ge.m
+++ b/matlab/ceq2ge.m
@@ -94,7 +94,7 @@ for p = 1:ceq.nParentBlocks
 
             % add delay and convert to Gauss/cm
             delay = zeros(1, round(g.delay/raster));
-            grad.(ax{1}) = [delay tmp]/ gamma * 100;   % Gauss/cm
+            grad.(ax{1}) = [delay tmp(:).']/ gamma * 100;   % Gauss/cm
         end
     end
 

--- a/matlab/ceq2ge.m
+++ b/matlab/ceq2ge.m
@@ -48,6 +48,14 @@ for p = 1:ceq.nParentBlocks
     if hasRF(p)
         b1ScalingFile = modFiles{p};
 
+        if b.rf.delay < sysGE.rfDeadTime*1e-6
+            error(sprintf('Parent block %d: RF delay must be >= sysGE.rfDeadTime', p));
+        end
+
+        if b.rf.delay + b.rf.shape_dur + sysGE.rfRingdownTime*1e-6 > b.blockDuration
+            error(sprintf('Parent block %d: RF ringdown extends past end of block', p));
+        end
+
         tge = raster/2 : raster : b.rf.shape_dur;
         rf = interp1(b.rf.t, b.rf.signal, tge, 'linear', 'extrap') / gamma * 1e4;  % Gauss
 
@@ -100,6 +108,12 @@ for p = 1:ceq.nParentBlocks
 
     % ADC
     if hasADC(p)
+        if b.adc.delay < sysGE.adcDeadTime*1e-6
+            error(sprintf('Parent block %d: ADC delay must be >= sysGE.adcDeadTime', p));
+        end
+        if b.adc.delay + b.adc.numSamples*b.adc.dwell > b.blockDuration
+            error(sprintf('Parent block %d: ADC window extends past end of block', p));
+        end
         npre = round(b.adc.delay/raster);
         rfres = round(b.adc.numSamples*b.adc.dwell/raster);
         readoutFile = modFiles{p};

--- a/matlab/gradinterp.m
+++ b/matlab/gradinterp.m
@@ -4,8 +4,8 @@ function wavOut = gradinterp(g, rasterIn, rasterOut)
 % Interpolate arbitrary gradient to uniform raster
 %
 % Intputs:
-%  g             Pulseq (arbitrary) gradient struct. Must define the following:
-%                g.waveform     gradient waveform samples (Hz/m)
+%  g             Pulseq (arbitrary) gradient struct. Must contain the following fields:
+%                g.waveform     gradient waveform samples (a.u.)
 %                g.tt           sample times (sec)
 %                g.first        waveform value at starting edge of 1st raster time
 %                g.last         waveform value at ending edge of last raster time
@@ -13,7 +13,7 @@ function wavOut = gradinterp(g, rasterIn, rasterOut)
 %  rasterOut     output gradient raster time (sec)
 %
 % Output:
-%  gout          gradient on uniform raster (Hz/m)
+%  gout          gradient on uniform raster
 %
 % To run test function:
 %  >> gradinterp('test');
@@ -95,7 +95,7 @@ g.tt = ([1:n]-0.5)*rasterIn;  % times at center of inputer raster intervals
 freq = 1000; % Hz 
 g.waveform = sin(2*pi*freq*g.tt);
 g.first = 0;
-g.last = g.waveform(end-1) + (g.waveform(end)-g.waveform(end-1))/2;
+g.last = g.waveform(end) + (g.waveform(end)-g.waveform(end-1))/2;
 
 gNoisy.waveform = g.waveform;
 gNoisy.tt = g.tt + tNoise*randn(1, length(g.tt));

--- a/matlab/gradinterp.m
+++ b/matlab/gradinterp.m
@@ -4,7 +4,7 @@ function wavOut = gradinterp(g, rasterIn, rasterOut)
 % Interpolate arbitrary gradient to uniform raster
 %
 % Intputs:
-%  g             Pulseq (arbitrary) gradient struct
+%  g             Pulseq (arbitrary) gradient struct. Must define the following:
 %                g.waveform     gradient waveform samples (Hz/m)
 %                g.tt           sample times (sec)
 %                g.first        waveform value at starting edge of 1st raster time
@@ -14,6 +14,9 @@ function wavOut = gradinterp(g, rasterIn, rasterOut)
 %
 % Output:
 %  gout          gradient on uniform raster (Hz/m)
+%
+% To run test function:
+%  >> gradinterp('test');
 
 if ischar(g)
     sub_test();
@@ -30,45 +33,78 @@ rasterOut = round(rasterOut/dt)*dt;
 ttIn = g.tt(:);
 wav = g.waveform(:);
 
-% If first sample is not at t=0, add g.first.
+% If first sample is not at t=0, add g.first
 % This is probably due to g.tt(1) = rasterIn/2
 if g.tt(1) > 0
     ttIn = [0; ttIn];
     wav = [g.first; wav];
 end
 
-% If last sample is not at end edge of last raster point, add g.last.
+% If last sample is not at end edge of last raster point, add g.last
 if mod(g.tt(end), rasterIn)
     ttIn = [ttIn; ttIn(end) + rasterIn - mod(ttIn(end), rasterIn)];
     wav = [wav; g.last];
 end
 
-% Slight distortion that we may have to ask for forgiveness for later: 
-% stretch time so end sample is on rasterOut boundary
-timeStretchFactor = (ceil(ttIn(end)/rasterOut)*rasterOut) / ttIn(end);
-ttIn = ttIn * timeStretchFactor;
+% Output sample times on regular raster.
 dt = 1e-9;
 ttIn = round(ttIn/dt)*dt; 
-ttOut = [0:rasterOut:ttIn(end)];
+ttOutLast = ceil(ttIn(end)/rasterOut)*rasterOut; % add sample at end if necessary to avoid extrapolation
+ttOut = [0:rasterOut:ttOutLast];
 
 wavOut = interp1(ttIn, wav, ttOut); %, 'interp', 'extrap');
 
 return
 
+
 function sub_test
 
-rasterIn = 10e-6;
-g.waveform = [1 1 0]*1e3;       
-g.tt = [0 100 400]*1e-6;
-g.first = g.waveform(1);
-g.last = g.waveform(end);
+% Define test waveform and sample times.
+% Sample times at center of rasterIn intervals, and not on 4us boundary
+rasterIn = 10e-6;   % Siemens gradient raster
+g.waveform = [1 1 0];   % gradient waveform, a.u.
+g.tt = [5 105 205]*1e-6;    % sample times, sec
+g.first = g.waveform(1);    % waveform at start edge of first raster time
+g.last = g.waveform(end);   % waveform at end edge of last raster time
 
+% Add time sample 'noise' to test robustness to roundoff error
+tNoise = 1e-11;   % sec
+rasterInNoisy = rasterIn + tNoise;
+gNoisy.waveform = g.waveform;
+gNoisy.tt = g.tt + tNoise*randn(1, length(g.tt));
+gNoisy.first = g.first;
+gNoisy.last = g.last;
+
+% Interpolate
 rasterOut = 4e-6;
+gout = gradinterp(gNoisy, rasterInNoisy, rasterOut + tNoise);
 
-gout = gradinterp(g, rasterIn, rasterOut);
+% Plot
+tt = (0:(length(gout)-1))*rasterOut;
+hold off;
+plot(g.tt*1e6, g.waveform, 'bo', 'MarkerSize', 8);
+hold on;
+plot(tt*1e6, gout, 'rx-');
+xlabel('time (us)');
 
-tt = (1:length(gout))*rasterOut;
+% Do it again for a sinusoidal waveform
+tNoise = 1e-11;   % sec
+rasterInNoisy = rasterIn + tNoise;
+n = 20;   % number of waveform samples
+g.tt = ([1:n]-0.5)*rasterIn;  % times at center of inputer raster intervals
+freq = 1000; % Hz 
+g.waveform = sin(2*pi*freq*g.tt);
+g.first = 0;
+g.last = g.waveform(end-1) + (g.waveform(end)-g.waveform(end-1))/2;
 
-plot(tt, gout, 'bo-');
+gNoisy.waveform = g.waveform;
+gNoisy.tt = g.tt + tNoise*randn(1, length(g.tt));
+gNoisy.first = g.first;
+gNoisy.last = g.last;
 
+gout = gradinterp(gNoisy, rasterInNoisy, rasterOut + tNoise);
+tt = (0:(length(gout)-1))*rasterOut;
+plot(g.tt*1e6, g.waveform, 'bo', 'MarkerSize', 8);
+plot(tt*1e6, gout, 'rx-');
 
+legend('Input waveform', 'Output waveform', 'Input waveform', 'Output waveform'); 

--- a/matlab/gradinterp.m
+++ b/matlab/gradinterp.m
@@ -94,6 +94,7 @@ plot(g.tt*1e6, g.waveform, 'bo', 'MarkerSize', 8);
 hold on;
 plot(ttOut*1e6, gOut, 'rx-');
 xlabel('time (us)');
+ylabel('Waveform amplitude (a.u.)');
 
 % Do it again for a sinusoidal waveform,
 % time samples at center of input raster times

--- a/matlab/gradinterp.m
+++ b/matlab/gradinterp.m
@@ -79,7 +79,7 @@ rasterInNoisy = rasterIn + tNoise;
 
 % Define test waveform and sample times.
 g.waveform = [1 1 0];   % gradient waveform, a.u.
-g.tt = [rasterIn/2 108e-6 20*rasterIn];    % sample times, sec
+g.tt = [rasterIn/2 58e-6 20*rasterIn];    % sample times, sec
 g.first = g.waveform(1);    % waveform at start edge of first raster time
 g.last = g.waveform(end);   % waveform at end edge of last raster time
 
@@ -102,7 +102,7 @@ tNoise = 1e-11;   % sec
 rasterInNoisy = rasterIn + tNoise;
 n = 20;   % number of waveform samples
 g.tt = ([1:n]-0.5)*rasterIn;
-freq = 1000; % Hz 
+freq = 2000; % Hz 
 g.waveform = sin(2*pi*freq*g.tt);
 g.first = 0;
 g.last = g.waveform(end) + (g.waveform(end)-g.waveform(end-1))/2;

--- a/matlab/seq2ge.m
+++ b/matlab/seq2ge.m
@@ -1,7 +1,35 @@
-function seq2ge(seqarg, sysGE, ofname)
+function seq2ge(seqarg, ofname, varargin)
+% Convert a Pulseq file (http://pulseq.github.io/) to a .tar file for GE scanners
+%
+% Inputs
+%   seqarg = a seq object, or name of a .seq file
+%
+% Ouputs
+%   none
+%
+% Effect
+%   Writes a .tar file containing all the required scan files to run on GE scanners
+
+% Parse inputs
+% Read in system specs defined from .seq file
+seq = mr.Sequence(); seq.read(seqarg); sys = seq.sys;
+
+% Define sysGE
+arg.sysGE = toppe.systemspecs(...
+    'psd_rf_wait', 200,... % us
+    'psd_grd_wait', 200,... % us
+    'maxGrad', sys.maxGrad/sys.gamma*100,... % G/cm
+    'maxSlew', 1.01*sys.maxSlew/sys.gamma/10,... % G/cm/ms. Factor > 1 is fudge factor to avoid exceeding limit after interpolating to GE raster time.
+    'rfDeadTime', sys.rfDeadTime*1e6,... % us
+    'rfRingdownTime', sys.rfRingdownTime*1e6,... % us
+    'adcDeadTime', sys.adcDeadTime*1e6...  % us
+);
+
+% Use explicitly provided sysGE (function from MIRT toolbox)
+arg = vararg_pair(arg, varargin);
 
 % Convert the .seq file/object to the PulCeq representation
 ceq = seq2ceq(seqarg);
 
 % Write to TOPPE files
-ceq2ge(ceq, sysGE, ofname);
+ceq2ge(ceq, arg.sysGE, ofname);


### PR DESCRIPTION
This allows users to simply receive a .seq file from someone and convert it to a .tar file to be prescribed to GE scanners without the need to explicitly define a sysGE object.